### PR TITLE
add G3P_GNUPLOT_PATH environment variable mechanism

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,9 @@ endif()
 #
 project(
   g3p
-  VERSION 0.7
+  VERSION 0.8
   LANGUAGES CXX
-  DESCRIPTION "The most intuitive header-only modern C++ interface library for gnuplot."
+  DESCRIPTION "gnuplot for Modern C++"
 )
 
 ## prevent in-source builds
@@ -46,7 +46,10 @@ endif()
 
 ## find gnuplot
 #
-find_package(Gnuplot REQUIRED)
+find_package(Gnuplot)
+if (NOT GNUPLOT_FOUND)
+  message(WARNING "g3p requires gnuplot executable to be in the PATH environment variable")
+endif()
 
 ## make cache variables for install destinations
 #
@@ -57,7 +60,6 @@ include(GNUInstallDirs)
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
-target_compile_definitions(${PROJECT_NAME} INTERFACE GNUPLOT="${GNUPLOT_EXECUTABLE}")
 target_include_directories(${PROJECT_NAME} INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
@@ -126,5 +128,3 @@ if (NOT_SUBPROJECT)
   #
   add_subdirectory(artwork)
 endif(NOT_SUBPROJECT)
-
-# add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center"><img src="artwork/g3p_logo.svg" width="256" height="200"></p>
 
 # What is g3p?
-`g3p` (**G**nu**P**lot **P**lus **P**lus) is a modern header-only C++ interface
+`g3p` (`G`nu`P`lot `P`lus `P`lus) is a header-only Modern C++ interface
 library for [gnuplot](http://www.gnuplot.info/). It is the most natural and
 intuitive way of adding `gnuplot` support into any C++ program.
 ## Features
@@ -58,12 +58,10 @@ Here's the output:
 [`include/g3p/gnuplot.hpp`](include/g3p/gnuplot.hpp)
 to your project or one of the designated system folders for headers (e.g.
 `/usr/include` or `/usr/local/include` on Linux systems)
-and start using by including it. That being said, this approach doesn't
-benefit from `g3p` ability to find the right path to `gnuplot` program and
-version on different platforms.
+and start using it.
 
 A better approach but not ideal is to build and install `g3p` using the
-following commands on any platform and then including `<g3p/gnuplot.hpp>`: 
+following commands and then including `<g3p/gnuplot.hpp>`:
 ```bash
 git clone https://github.com/arminms/g3p.git
 cd g3p
@@ -83,8 +81,6 @@ find_package(g3p REQUIRED)
 add_executable(test test.cpp)
 target_link_libraries(test PRIVATE g3p::g3p)
 ```
-*There is no need to add `find_package(Gnuplot)` because CMake config provided by
-`g3p` will take care of that.*
 
 Another possibility is to mix `find_package()` with
 [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html)
@@ -95,7 +91,7 @@ find_package(
   g3p CONFIG
   HINTS $ENV{HOME} $ENV{HOME}/.local /usr/local /usr
 )
-if(NOT g3p_DIR)
+if(NOT g3p_FOUND)
     message(STATUS "Fetching g3p library...")
     include(FetchContent)
     FetchContent_Declare(

--- a/include/g3p/gnuplot.hpp
+++ b/include/g3p/gnuplot.hpp
@@ -25,11 +25,8 @@
 #include <cstdio>
 #include <stdexcept>
 #include <string>
+#include <cstdlib>
 #include <type_traits>
-
-#ifndef GNUPLOT
-#   define GNUPLOT "gnuplot"
-#endif  // GNUPLOT
 
 namespace g3p {
 
@@ -54,25 +51,17 @@ class gnuplot
 public:
     gnuplot(bool persist = true)
     {
+        const char* gnuplot_path = std::getenv("G3P_GNUPLOT_PATH");
+        std::string gnuplot_cmd = gnuplot_path ? gnuplot_path : "gnuplot";
+        if (persist) gnuplot_cmd += " -persist";
 #ifdef _MSC_VER // possibly _WIN32 for MingW-64?
         _gp = _popen
-        (   persist
-        ?   "GNUPLOT -persist"
-        :   "GNUPLOT"
-        ,   "w"
-        );
-        if (nullptr == _gp)
-            throw std::domain_error("GNUPLOT -- failed");
 #else
-        _gp = popen
-        (   persist
-        ?   GNUPLOT" -persist"
-        :   GNUPLOT
-        ,   "w"
-        );
-        if (nullptr == _gp)
-            throw std::domain_error(GNUPLOT" -- failed");
+        _gp =  popen
 #endif //_MSC_VER
+            (gnuplot_cmd.c_str(), "w");
+        if (nullptr == _gp)
+            throw std::domain_error("gnuplot -- failed");
     }
 
     ~gnuplot()


### PR DESCRIPTION
With this change, g3p is now relies on gnuplot executable to be on PATH environment variable. If not, it's possible to set G3P_GNUPLOT_PATH environment variable to the right path.